### PR TITLE
Make sure the Content-Length header is sent for POSTs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
+1.1.1  March 5, 2012
+  - Make sure the Content-Length header is sent for POSTs
+
 1.1.0  March 5, 2012
   - Better error handling
   - Handle requests with no parameters specified
   - Add login_url() example
 
 1.0.0  January 16, 2012
-  - Initial public release 
+  - Initial public release

--- a/lib/yellowbot.js
+++ b/lib/yellowbot.js
@@ -139,6 +139,8 @@ api.get = function(method, params, cb) {
 
 api.post = function(method, params, data, cb) {
 
+    var body = JSON.stringify(data);
+
     params = _.clone(params);
     _sign(params);
 
@@ -151,7 +153,8 @@ api.post = function(method, params, data, cb) {
                 headers: _.extend({},
                     api.server.headers,
                     {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'Content-Length': body.length
                     }
                 )
             }
@@ -164,7 +167,7 @@ api.post = function(method, params, data, cb) {
         cb && cb(e.message);
     });
 
-    req.write(JSON.stringify(data));
+    req.write(body);
     req.end();
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Ask Bjørn Hansen <ask@develooper.com> (http://www.solfo.com/)",
   "name": "yellowbot",
   "description": "YellowBot API wrapper",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/solfo/node-yellowbot",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should resolve the recent issue of not being able to register users in prod.

Graham suspects that Perlbal was adding the _Content-Length_ header, which is why it worked without a hitch prior.
